### PR TITLE
Use table.pack to pass and return nil values

### DIFF
--- a/src/lib.lua
+++ b/src/lib.lua
@@ -2,21 +2,20 @@ local co = coroutine
 
 function async(f)
     return function(...)
-        local params = {...}
+        local params = table.pack(...)
         local thread = co.create(function()
-            return f(table.unpack(params))
+            return f(table.unpack(params, 1, params.n))
         end)
 
         return function(cb)
             local step = nil
             step = function(...)
-                local result = {co.resume(thread, ...)}
-                table.remove(result, 1)
+                local result = table.pack(co.resume(thread, ...))
 
                 if co.status(thread) == "dead" then
-                    cb(table.unpack(result))
+                    (cb or function() end)(table.unpack(result, 2, result.n))
                 else
-                    local f = table.unpack(result)
+                    local f = result[2]
                     assert(type(f) == "function", "type error :: expected func")
                     f(step)
                 end
@@ -28,10 +27,10 @@ end
 
 function wrap(f)
     return function(...)
-        local params = {...}
+        local params = table.pack(...)
         return function(cb)
-            table.insert(params, cb)
-            f(table.unpack(params))
+            table.insert(params, params.n + 1, cb)
+            f(table.unpack(params, 1, params.n + 1))
         end
     end
 end

--- a/src/lib_spec.lua
+++ b/src/lib_spec.lua
@@ -27,6 +27,28 @@ describe("a", function()
         assert.are.equal(42, calledWith)
     end)
 
+    it("passes nil to the function", function()
+        local f = a.sync(function(a, b, c)
+            assert.are.equal(a, 1)
+            assert.are.equal(b, nil)
+            assert.are.equal(c, 3)
+        end)
+
+        f(1, nil, 3)()
+    end)
+
+    it("returns nil from the function", function()
+        local f = a.sync(function()
+            return 1, nil, 3
+        end)
+
+        f()(function(a, b, c)
+            assert.are.equal(a, 1)
+            assert.are.equal(b, nil)
+            assert.are.equal(c, 3)
+        end)
+    end)
+
     it("wrap provides callback to function", function()
         local f = a.wrap(function(n, cb)
             cb(n + 1)
@@ -38,6 +60,17 @@ describe("a", function()
         end)
 
         assert.are.equal(42, calledWith)
+    end)
+
+    it("wrap passes nil to function", function()
+        local f = a.wrap(function(a, b, c, cb)
+            assert.are.equal(a, 1)
+            assert.are.equal(b, nil)
+            assert.are.equal(c, 3)
+            cb()
+        end)
+
+        f(1, nil, 3)(function() end)
     end)
 
     it("await returns result of function", function()


### PR DESCRIPTION
In Lua, table.unpack will stop at the first nil value it finds. This means that wrap and async will not pass a complete set of arguments to the wrapped function if one of the arguments is nil.

Use table.pack instead of {...} to count the number of packed values and provide a range to table.unpack to unpack all the values.

Do the same thing to handle results with nil values returned from a coroutine. Since table.remove also stops updating remaining table values when it encounters a nil and does not accept a range, leave the coroutine result and return an offset range of unpacked values.

Add some new tests to validate the expected behavior.